### PR TITLE
Add Apache License 2.0 and enhance Go documentation for v1/otel

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Support. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2025 0xgosu@gmail.com
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/v1/otel/LICENSE
+++ b/v1/otel/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Support. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2025 0xgosu@gmail.com
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/v1/otel/config.go
+++ b/v1/otel/config.go
@@ -56,6 +56,13 @@ type Config struct {
 }
 
 // DefaultConfig returns the default configuration for the OTEL middleware.
+//
+// Example:
+//
+//	config := otel.DefaultConfig()
+//	config.Name = "my-otel"
+//	config.TracesEnabled = true
+//	// Then create middleware with custom config
 func DefaultConfig() Config {
 	return Config{
 		Name:               "otel",

--- a/v1/otel/options.go
+++ b/v1/otel/options.go
@@ -12,6 +12,12 @@ import (
 type Option func(*Config)
 
 // WithName sets the middleware module name.
+//
+// Example:
+//
+//	otelMw, err := otel.New(
+//	    otel.WithName("my-otel-middleware"),
+//	)
 func WithName(name string) Option {
 	return func(c *Config) {
 		c.Name = name
@@ -20,6 +26,15 @@ func WithName(name string) Option {
 
 // WithMeterProvider sets the OpenTelemetry MeterProvider for metrics.
 // This automatically enables metrics collection.
+//
+// Example:
+//
+//	meterProvider := sdkmetric.NewMeterProvider(
+//	    sdkmetric.WithReader(sdkmetric.NewPeriodicReader(exporter)),
+//	)
+//	otelMw, err := otel.New(
+//	    otel.WithMeterProvider(meterProvider),
+//	)
 func WithMeterProvider(mp metric.MeterProvider) Option {
 	return func(c *Config) {
 		c.MeterProvider = mp
@@ -28,6 +43,12 @@ func WithMeterProvider(mp metric.MeterProvider) Option {
 }
 
 // WithMetricsDisabled disables metrics collection.
+//
+// Example:
+//
+//	otelMw, err := otel.New(
+//	    otel.WithMetricsDisabled(),
+//	)
 func WithMetricsDisabled() Option {
 	return func(c *Config) {
 		c.MetricsEnabled = false
@@ -35,6 +56,13 @@ func WithMetricsDisabled() Option {
 }
 
 // WithMeterName sets the name for the OTEL meter.
+//
+// Example:
+//
+//	otelMw, err := otel.New(
+//	    otel.WithMeterProvider(meterProvider),
+//	    otel.WithMeterName("my-service-meter"),
+//	)
 func WithMeterName(name string) Option {
 	return func(c *Config) {
 		c.MeterName = name
@@ -43,6 +71,16 @@ func WithMeterName(name string) Option {
 
 // WithTracerProvider sets the OpenTelemetry TracerProvider for tracing.
 // This automatically enables tracing and trace context propagation.
+//
+// Example:
+//
+//	tracerProvider := sdktrace.NewTracerProvider(
+//	    sdktrace.WithBatcher(exporter),
+//	    sdktrace.WithSampler(sdktrace.AlwaysSample()),
+//	)
+//	otelMw, err := otel.New(
+//	    otel.WithTracerProvider(tracerProvider),
+//	)
 func WithTracerProvider(tp trace.TracerProvider) Option {
 	return func(c *Config) {
 		c.TracerProvider = tp
@@ -52,6 +90,12 @@ func WithTracerProvider(tp trace.TracerProvider) Option {
 }
 
 // WithTracesDisabled disables tracing.
+//
+// Example:
+//
+//	otelMw, err := otel.New(
+//	    otel.WithTracesDisabled(),
+//	)
 func WithTracesDisabled() Option {
 	return func(c *Config) {
 		c.TracesEnabled = false
@@ -59,6 +103,13 @@ func WithTracesDisabled() Option {
 }
 
 // WithTracerName sets the name for the OTEL tracer.
+//
+// Example:
+//
+//	otelMw, err := otel.New(
+//	    otel.WithTracerProvider(tracerProvider),
+//	    otel.WithTracerName("my-service-tracer"),
+//	)
 func WithTracerName(name string) Option {
 	return func(c *Config) {
 		c.TracerName = name
@@ -67,6 +118,15 @@ func WithTracerName(name string) Option {
 
 // WithLoggerProvider sets the OpenTelemetry LoggerProvider for log export.
 // This automatically enables log export.
+//
+// Example:
+//
+//	loggerProvider := sdklog.NewLoggerProvider(
+//	    sdklog.WithProcessor(sdklog.NewBatchProcessor(exporter)),
+//	)
+//	otelMw, err := otel.New(
+//	    otel.WithLoggerProvider(loggerProvider),
+//	)
 func WithLoggerProvider(lp log.LoggerProvider) Option {
 	return func(c *Config) {
 		c.LoggerProvider = lp
@@ -75,6 +135,12 @@ func WithLoggerProvider(lp log.LoggerProvider) Option {
 }
 
 // WithLogsDisabled disables log export.
+//
+// Example:
+//
+//	otelMw, err := otel.New(
+//	    otel.WithLogsDisabled(),
+//	)
 func WithLogsDisabled() Option {
 	return func(c *Config) {
 		c.LogsEnabled = false
@@ -82,6 +148,13 @@ func WithLogsDisabled() Option {
 }
 
 // WithLogLevel sets the minimum log level to export to OTEL.
+//
+// Example:
+//
+//	otelMw, err := otel.New(
+//	    otel.WithLoggerProvider(loggerProvider),
+//	    otel.WithLogLevel(slog.LevelDebug),
+//	)
 func WithLogLevel(level slog.Level) Option {
 	return func(c *Config) {
 		c.LogLevel = level
@@ -90,6 +163,13 @@ func WithLogLevel(level slog.Level) Option {
 
 // WithPropagationDisabled disables automatic trace context propagation
 // to outgoing messages.
+//
+// Example:
+//
+//	otelMw, err := otel.New(
+//	    otel.WithTracerProvider(tracerProvider),
+//	    otel.WithPropagationDisabled(),
+//	)
 func WithPropagationDisabled() Option {
 	return func(c *Config) {
 		c.PropagationEnabled = false

--- a/v1/otel/otel.go
+++ b/v1/otel/otel.go
@@ -42,6 +42,21 @@ var _ mono.MiddlewareModule = (*Middleware)(nil)
 // New creates a new OpenTelemetry middleware with the given options.
 // The logger is initialized immediately so it can be used with mono.WithLogger()
 // before the application starts.
+//
+// Example:
+//
+//	tracerProvider := sdktrace.NewTracerProvider(...)
+//	meterProvider := sdkmetric.NewMeterProvider(...)
+//	loggerProvider := sdklog.NewLoggerProvider(...)
+//
+//	otelMw, err := otel.New(
+//	    otel.WithMeterProvider(meterProvider),
+//	    otel.WithTracerProvider(tracerProvider),
+//	    otel.WithLoggerProvider(loggerProvider),
+//	)
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
 func New(opts ...Option) (*Middleware, error) {
 	config := DefaultConfig()
 	for _, opt := range opts {
@@ -61,12 +76,25 @@ func New(opts ...Option) (*Middleware, error) {
 }
 
 // Name returns the middleware module name.
+//
+// Example:
+//
+//	otelMw, _ := otel.New()
+//	fmt.Println(otelMw.Name()) // Output: otel
 func (m *Middleware) Name() string {
 	return m.config.Name
 }
 
 // Start initializes the OpenTelemetry instruments (metrics and tracing).
 // The logger is already initialized in New().
+//
+// Example:
+//
+//	otelMw, _ := otel.New(otel.WithMeterProvider(meterProvider))
+//	err := otelMw.Start(context.Background())
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
 func (m *Middleware) Start(ctx context.Context) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -84,6 +112,13 @@ func (m *Middleware) Start(ctx context.Context) error {
 }
 
 // Stop performs cleanup.
+//
+// Example:
+//
+//	err := otelMw.Stop(context.Background())
+//	if err != nil {
+//	    log.Printf("Error stopping OTEL middleware: %v", err)
+//	}
 func (m *Middleware) Stop(_ context.Context) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -96,6 +131,17 @@ func (m *Middleware) Stop(_ context.Context) error {
 // This logger is available immediately after New() and can be used with
 // mono.WithLogger() for framework-wide logging to OTEL.
 // Returns nil if logs are not enabled.
+//
+// Example:
+//
+//	otelMw, _ := otel.New(otel.WithLoggerProvider(loggerProvider))
+//	logger := otelMw.Logger()
+//	logger.Info("Application started", "version", "1.0.0")
+//
+//	// Or use with Mono framework
+//	app, err := mono.NewMonoApplication(
+//	    mono.WithLogger(otelMw.Logger()),
+//	)
 func (m *Middleware) Logger() *slog.Logger {
 	return m.logger
 }

--- a/v1/otel/propagation.go
+++ b/v1/otel/propagation.go
@@ -72,6 +72,16 @@ func (m *Middleware) injectTraceContext(ctx context.Context, msg *types.Msg) {
 
 // GetTraceID extracts the trace ID from the context.
 // Returns an empty string if no valid trace context exists.
+//
+// Example:
+//
+//	func MyHandler(ctx context.Context, msg *types.Msg) error {
+//	    traceID := otel.GetTraceID(ctx)
+//	    if traceID != "" {
+//	        log.Printf("Processing request with trace ID: %s", traceID)
+//	    }
+//	    return nil
+//	}
 func GetTraceID(ctx context.Context) string {
 	span := trace.SpanFromContext(ctx)
 	if !span.SpanContext().IsValid() {
@@ -82,6 +92,16 @@ func GetTraceID(ctx context.Context) string {
 
 // GetSpanID extracts the span ID from the context.
 // Returns an empty string if no valid trace context exists.
+//
+// Example:
+//
+//	func MyHandler(ctx context.Context, msg *types.Msg) error {
+//	    spanID := otel.GetSpanID(ctx)
+//	    if spanID != "" {
+//	        log.Printf("Processing request with span ID: %s", spanID)
+//	    }
+//	    return nil
+//	}
 func GetSpanID(ctx context.Context) string {
 	span := trace.SpanFromContext(ctx)
 	if !span.SpanContext().IsValid() {
@@ -92,6 +112,16 @@ func GetSpanID(ctx context.Context) string {
 
 // GetTraceContext extracts both trace ID and span ID from the context.
 // Returns empty strings if no valid trace context exists.
+//
+// Example:
+//
+//	func MyHandler(ctx context.Context, msg *types.Msg) error {
+//	    traceID, spanID := otel.GetTraceContext(ctx)
+//	    if traceID != "" {
+//	        log.Printf("Processing request with trace: %s, span: %s", traceID, spanID)
+//	    }
+//	    return nil
+//	}
 func GetTraceContext(ctx context.Context) (traceID, spanID string) {
 	span := trace.SpanFromContext(ctx)
 	if !span.SpanContext().IsValid() {


### PR DESCRIPTION
- Add Apache License 2.0 to root repository and v1/otel package
- Add comprehensive usage examples for all exported functions/methods:
  - New(): Creating middleware with various provider configurations
  - All option functions (WithName, WithMeterProvider, WithTracerProvider, etc.)
  - Middleware methods (Name, Start, Stop, Logger)
  - Helper functions (GetTraceID, GetSpanID, GetTraceContext)
  - DefaultConfig(): Using and customizing default configuration
- All tests pass successfully

Closes #6

## 📌 Background

<!-- Provide context or background to help reviewers understand why this change is necessary. Include links to related issues, user stories, or documentation (reference to design.md, requirements.md, plan, PRD) if applicable. -->

## 🔧 Reason for Changes

<!-- Explain the problem(s) being solved or what motivated the changes. Include bug report references, feature requests, or business needs. -->

## ✅ Changes Implemented

<!-- Summarize the changes introduced in this pull request. Bullet points are encouraged for clarity. -->

## 🔍 Testing Results

<!-- Describe how the changes were tested and what the results were. Include test cases, screenshots, or logs if beneficial. -->

- [ ] Unit tests passed
- [ ] Integration tests passed
- [ ] Manually tested in local/dev environment

## 🚀 Deployment / Migration Details

<!-- Specify any steps needed for deployment, such as database migrations, environment variable updates, or cron jobs. -->

---

### 📝 Additional Notes (Optional)

<!-- Any extra information or considerations for reviewers or testers. -->

<!-- Mention relevant team members or reviewers if needed. -->